### PR TITLE
Replace toplevel domain .com with .io in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-[jADT](http://jamesiry.github.com/jADT/index.html) turns [algebraic datatype](http://jamesiry.github.com/jADT/what_adt.html) description [files](http://jamesiry.github.com/jADT/syntax.html) into [Java source files](http://jamesiry.github.com/jADT/how_adt.html). The resulting Java is nearly as easy to use as an Enum, but [far more flexible](http://jamesiry.github.com/jADT/why_adt.html).
+[jADT](http://jamesiry.github.io/jADT/index.html) turns [algebraic datatype](http://jamesiry.github.io/jADT/what_adt.html) description [files](http://jamesiry.github.io/jADT/syntax.html) into [Java source files](http://jamesiry.github.io/jADT/how_adt.html). The resulting Java is nearly as easy to use as an Enum, but [far more flexible](http://jamesiry.github.io/jADT/why_adt.html).
 
 _Copyright 2012 James Iry_


### PR DESCRIPTION
It's a small change, so why not.